### PR TITLE
Add target selection via KConfig, fix include files for stub library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,23 @@
 # BSP target selection
-if (NOT DEFINED BSP_TARGET)
-    set(BSP_TARGET "stub")
+
+if (CONFIG_BSP_TARGET_WHY2025)
+	set(BSP_TARGET "why2025")
+elseif(CONFIG_BSP_PLATFORM_P4_DEVKIT)
+	set(BSP_TARGET "why2025")
+elseif(CONFIG_BSP_TARGET_MCH2022)
+	set(BSP_TARGET "mch2022")
+else()
+	set(BSP_TARGET "stub")
 endif()
+
+# BSP requirements for all targets
+
+set(COMMON_BSP_REQUIREMENTS
+    "esp_lcd"
+    "driver"
+)
+
+# -------------------------
 
 set(TARGETS_FOLDER "${CMAKE_CURRENT_LIST_DIR}/targets")
 
@@ -20,6 +36,8 @@ endif()
 if (NOT DEFINED BSP_REQUIRES)
   set(BSP_REQUIRES "")
 endif()
+
+list(APPEND BSP_REQUIRES ${COMMON_BSP_REQUIREMENTS})
 
 if (NOT DEFINED BSP_SRCS)
     file(GLOB BSP_SRCS
@@ -54,6 +72,7 @@ target_include_directories(
     bsp_stub
     PUBLIC
     "."
+    "$<TARGET_PROPERTY:${COMPONENT_LIB},INTERFACE_INCLUDE_DIRECTORIES>"
 )
 
 target_link_libraries(${COMPONENT_LIB} PRIVATE bsp_stub)

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,18 @@
+menu "Badge.Team BSP"
+	choice
+		prompt "Board"
+		default BSP_TARGET_WHY2025
+
+		config BSP_TARGET_WHY2025
+			bool "WHY2025 badge"
+
+		config BSP_TARGET_P4_DEVKIT
+			bool "ESP32 P4 devkit"
+
+		config BSP_TARGET_MCH2022
+			bool "MCH2022 badge"
+
+		config BSP_TARGET_STUB
+			bool "Generic (stub)"
+	endchoice
+endmenu


### PR DESCRIPTION
This fixes a problem where the include directories of required components are not made available to the stub library.
It also adds a way of adding common requirements (so that the common headers can include files from these components) and a KConfig option for selecting the target which replaces the earlier "-DBSP_TARGET why2025" approach.