### PR TITLE
Add wrapper API for converting esp_err_t errors into bsp_err_t errors

### DIFF
--- a/bsp/wrapped/bsp_errr.h
+++ b/bsp/wrapped/bsp_errr.h
@@ -1,0 +1,26 @@
+#pragma once
+
+typedef int bsp_err_t;
+
+#define BSP_OK   0
+#define BSP_FAIL -1
+
+#define BSP_ERR_NO_MEM           0x101
+#define BSP_ERR_INVALID_ARG      0x102
+#define BSP_ERR_INVALID_STATE    0x103
+#define BSP_ERR_INVALID_SIZE     0x104
+#define BSP_ERR_NOT_FOUND        0x105
+#define BSP_ERR_NOT_SUPPORTED    0x106
+#define BSP_ERR_TIMEOUT          0x107
+#define BSP_ERR_INVALID_RESPONSE 0x108
+#define BSP_ERR_INVALID_CRC      0x109
+#define BSP_ERR_INVALID_VERSION  0x10A
+#define BSP_ERR_INVALID_MAC      0x10B
+#define BSP_ERR_NOT_FINISHED     0x10C
+#define BSP_ERR_NOT_ALLOWED      0x10D
+
+#define BSP_ERR_WIFI_BASE      0x3000
+#define BSP_ERR_MESH_BASE      0x4000
+#define BSP_ERR_FLASH_BASE     0x6000
+#define BSP_ERR_HW_CRYPTO_BASE 0xc000
+#define BSP_ERR_MEMPROT_BASE   0xd000

--- a/bsp/wrapper.h
+++ b/bsp/wrapper.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "bsp/wrapped/bsp_err.h"
+#include "esp_err.h"
+
+bsp_err_t bsp_wrapper_convert_error(esp_err_t error);

--- a/common/bsp_common.c
+++ b/common/bsp_common.c
@@ -1,1 +1,0 @@
-// Dummy file for now

--- a/common/wrapper.c
+++ b/common/wrapper.c
@@ -1,0 +1,28 @@
+#include "bsp/wrapper.h"
+#include "bsp/wrapped/error.h"
+
+bsp_err_t bsp_wrapper_convert_error(esp_err_t error) {
+    if (error == ESP_OK) return BSP_OK;
+    if (error == ESP_FAIL) return BSP_FAIL;
+
+    if (error == ESP_ERR_NO_MEM) return BSP_ERR_NO_MEM;
+    if (error == ESP_ERR_INVALID_ARG) return BSP_ERR_INVALID_ARG;
+    if (error == ESP_ERR_INVALID_STATE) return BSP_ERR_INVALID_STATE;
+    if (error == ESP_ERR_INVALID_SIZE) return BSP_ERR_INVALID_SIZE;
+    if (error == ESP_ERR_NOT_FOUND) return BSP_ERR_NOT_FOUND;
+    if (error == ESP_ERR_NOT_SUPPORTED) return BSP_ERR_NOT_SUPPORTED;
+    if (error == ESP_ERR_TIMEOUT) return BSP_ERR_TIMEOUT;
+    if (error == ESP_ERR_INVALID_RESPONSE) return BSP_ERR_INVALID_RESPONSE;
+    if (error == ESP_ERR_INVALID_CRC) return BSP_ERR_INVALID_CRC;
+    if (error == ESP_ERR_INVALID_VERSION) return BSP_ERR_INVALID_VERSION;
+    if (error == ESP_ERR_INVALID_MAC) return BSP_ERR_INVALID_MAC;
+    if (error == ESP_ERR_NOT_FINISHED) return BSP_ERR_NOT_FINISHED;
+    if (error == ESP_ERR_NOT_ALLOWED) return BSP_ERR_NOT_ALLOWED;
+
+    if (error == ESP_ERR_WIFI_BASE) return BSP_ERR_WIFI_BASE;
+    if (error == ESP_ERR_MESH_BASE) return BSP_ERR_MESH_BASE;
+    if (error == ESP_ERR_FLASH_BASE) return BSP_ERR_FLASH_BASE;
+    if (error == ESP_ERR_HW_CRYPTO_BASE) return BSP_ERR_HW_CRYPTO_BASE;
+    if (error == ESP_ERR_MEMPROT_BASE) return BSP_ERR_MEMPROT_BASE;
+    return BSP_FAIL;
+}


### PR DESCRIPTION
Initial implementation which does not include wifi, mesh, flash, hw crypto and memprot errors yet.