### PR TITLE
Add display flush callback and blit function

### DIFF
--- a/bsp/display.h
+++ b/bsp/display.h
@@ -78,3 +78,7 @@ esp_err_t bsp_display_get_tearing_effect_mode(bsp_display_te_mode_t* mode);
 /// @brief Get handle for the tearing effect (TE) semaphore
 /// @return ESP-IDF error code
 esp_err_t bsp_display_get_tearing_effect_semaphore(SemaphoreHandle_t* semaphore);
+
+/// @brief Send pixel data to the display
+/// @return ESP-IDF error code
+esp_err_t bsp_display_blit(size_t x, size_t y, size_t width, size_t height, const void* buffer);

--- a/stub/badge_bsp_display.c
+++ b/stub/badge_bsp_display.c
@@ -48,3 +48,8 @@ esp_err_t __attribute__((weak)) bsp_display_get_tearing_effect_mode(bsp_display_
 esp_err_t __attribute__((weak)) bsp_display_get_tearing_effect_semaphore(SemaphoreHandle_t* semaphore) {
     return ESP_ERR_NOT_SUPPORTED;
 }
+
+esp_err_t __attribute__((weak)) bsp_display_blit(size_t x_start, size_t y_start, size_t x_end, size_t y_end,
+                                                 const void* buffer) {
+    return ESP_ERR_NOT_SUPPORTED;
+}

--- a/targets/esp32-p4-function-ev-board/badge_bsp_display.c
+++ b/targets/esp32-p4-function-ev-board/badge_bsp_display.c
@@ -25,12 +25,19 @@ static char const* TAG = "BSP display";
 
 static esp_ldo_channel_handle_t ldo_mipi_phy            = NULL;
 static bool                     bsp_display_initialized = false;
+static SemaphoreHandle_t        flush_semaphore         = NULL;
 
 #define BSP_LCD_RESET_PIN 7
 #define BSP_LCD_PWM_PIN   8
 
 #define BSP_DSI_LDO_CHAN       3
 #define BSP_DSI_LDO_VOLTAGE_MV 2500
+
+IRAM_ATTR static bool bsp_display_flush_ready(esp_lcd_panel_handle_t panel, esp_lcd_dpi_panel_event_data_t* edata,
+                                              void* user_ctx) {
+    xSemaphoreGiveFromISR(flush_semaphore, NULL);
+    return false;
+}
 
 static esp_err_t bsp_display_enable_dsi_phy_power(void) {
     if (ldo_mipi_phy != NULL) {
@@ -41,6 +48,15 @@ static esp_err_t bsp_display_enable_dsi_phy_power(void) {
         .voltage_mv = BSP_DSI_LDO_VOLTAGE_MV,
     };
     return esp_ldo_acquire_channel(&ldo_mipi_phy_config, &ldo_mipi_phy);
+}
+
+static esp_err_t bsp_display_initialize_flush(void) {
+    flush_semaphore = xSemaphoreCreateBinary();
+    xSemaphoreGive(flush_semaphore);
+    esp_lcd_dpi_panel_event_callbacks_t callbacks = {
+        .on_color_trans_done = bsp_display_flush_ready,
+    };
+    return esp_lcd_dpi_panel_register_event_callbacks(ek79007_get_panel(), &callbacks, NULL);
 }
 
 static esp_err_t bsp_display_initialize_panel(void) {
@@ -56,6 +72,7 @@ esp_err_t bsp_display_initialize(void) {
     }
     ESP_RETURN_ON_ERROR(bsp_display_enable_dsi_phy_power(), TAG, "Failed to enable DSI PHY power");
     ESP_RETURN_ON_ERROR(bsp_display_initialize_panel(), TAG, "Failed to initialize panel");
+    ESP_RETURN_ON_ERROR(bsp_display_initialize_flush(), TAG, "Failed to initialize flush callback");
     bsp_display_initialized = true;
     return ESP_OK;
 }
@@ -94,4 +111,9 @@ esp_err_t bsp_display_get_panel_io(esp_lcd_panel_io_handle_t* panel_io) {
 
 bsp_display_rotation_t bsp_display_get_default_rotation() {
     return BSP_DISPLAY_ROTATION_0;
+}
+
+esp_err_t bsp_display_blit(size_t x_start, size_t y_start, size_t x_end, size_t y_end, const void* buffer) {
+    xSemaphoreTake(flush_semaphore, pdMS_TO_TICKS(1000));
+    return esp_lcd_panel_draw_bitmap(ek79007_get_panel(), x_start, y_start, x_end, y_end, buffer);
 }


### PR DESCRIPTION
This helper function allows for using the display without requiring knowledge about ESP-IDF driver handles. We will need this for the ELF loader (& it's easier to use than having to set up this stuff in each app.

Should not break old apps, you can always just override the callback (although this does not currently expose any method for re-attaching the callback if you'd want that, might be something for a future PR).

Tested on: Tanmatsu, MCH2022 and P4 function EV board