### PR TITLE
bsp/tanmatsu: transmit Philips-framed I2S to match ES8156 config

### DIFF
--- a/targets/tanmatsu/badge_bsp_audio.c
+++ b/targets/tanmatsu/badge_bsp_audio.c
@@ -29,7 +29,7 @@ static esp_err_t initialize_i2s(uint32_t rate) {
 
     i2s_std_config_t i2s_config = {
         .clk_cfg  = I2S_STD_CLK_DEFAULT_CONFIG(rate),
-        .slot_cfg = I2S_STD_MSB_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO),
+        .slot_cfg = I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO),
         .gpio_cfg =
             {
                 .mclk = BSP_I2S_MCLK,


### PR DESCRIPTION
The Tanmatsu audio BSP configured the P4's I2S transmitter with I2S_STD_MSB_SLOT_DEFAULT_CONFIG (left-justified/MSB slot format), but es8156_configure programs the ES8156 codec for standard I2S ("Philips") framing (SDP REG11 sp_protocal=0). MSB and Philips differ by one BCLK of data delay after each WS edge, so the codec sampled the serial stream one bit skewed from where the transmitter put the MSB.

Effect: onset crackle on loud transients, gain-sensitive, present on both speaker and headphone outputs.