### PR TITLE
bsp/tanmatsu: initialize codec volume to 90 percent

### DIFF
--- a/targets/tanmatsu/badge_bsp_audio.c
+++ b/targets/tanmatsu/badge_bsp_audio.c
@@ -80,6 +80,8 @@ esp_err_t bsp_audio_initialize() {
     res = es8156_configure(codec_handle);
     if (res != ESP_OK) return res;
 
+    ESP_RETURN_ON_ERROR(bsp_audio_set_volume(90.0f), TAG, "Failed to set default codec volume");
+
     return initialize_i2s(44100);
 }
 


### PR DESCRIPTION
The generic ES8156 driver leaves its raw volume register at 100 after codec configuration. On Tanmatsu, that is only about 56% of the badge BSP's public 0..100 volume scale because bsp_audio_set_volume maps the scale to the codec's full 0..180 register range. Applications which do not immediately set their own volume therefore inherit an implicit, unusually quiet driver default rather than a board-level output setting.

Set a defined Tanmatsu startup volume of 90% after configuring the codec. The level is below the 100% setting that overloaded an external analog-loop capture, while remaining close to the clean 88% measurement. Applications can still override it through the existing bsp_audio_set_volume API.

The setting belongs in badge-bsp rather than the generic ES8156 component: the BSP owns the board's analog output policy, while the codec driver remains usable on boards with different output stages.