### PR TITLE
Select BOOTLOADER_CUSTOM_RESERVE_RTC so bsp_device_restart_to_launcher() builds out of the box

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -40,4 +40,20 @@ menu "Badge.Team BSP"
 			bool "WHY2025 badge"
 
 	endchoice
+
+	config BSP_RESERVE_RTC_RETAIN_MEM
+		bool
+		default y
+		select BOOTLOADER_CUSTOM_RESERVE_RTC
+		help
+			bsp_device_restart_to_launcher() (implemented as a weak
+			fallback in stub/badge_bsp_device.c and always linked into
+			every target because bsp_stub is unconditionally added to
+			the component) calls bootloader_common_get_rtc_retain_mem()
+			from bootloader_support. That function is only declared when
+			CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC is enabled, and the
+			underlying CONFIG_BOOTLOADER_RESERVE_RTC_MEM symbol it
+			selects has no prompt, so it cannot be set directly from a
+			downstream project's sdkconfig.defaults. Select it here
+			instead of requiring every consumer to discover this.
 endmenu


### PR DESCRIPTION
## The bug

This component's `CMakeLists.txt` unconditionally builds and links a `bsp_stub` static library into every consumer, regardless of which `CONFIG_BSP_TARGET_*` is selected:

```cmake
target_link_libraries(${COMPONENT_LIB} PRIVATE bsp_stub)
```

That line is not inside any target-specific `if`/`elseif` branch, so `stub/badge_bsp_device.c` always gets compiled and linked. Its (weak) `bsp_device_restart_to_launcher()` calls `bootloader_common_get_rtc_retain_mem()`, an ESP-IDF `bootloader_support` function used to signal "boot back into the launcher" across a restart via retained RTC FAST memory.

That function's declaration in ESP-IDF's `bootloader_support/include/bootloader_common.h` is entirely wrapped in `#ifdef CONFIG_BOOTLOADER_RESERVE_RTC_MEM ... #endif`. `CONFIG_BOOTLOADER_RESERVE_RTC_MEM` is declared in IDF's `components/bootloader/Kconfig.projbuild` as a **promptless, select-only** bool (`bool`, no default, no prompt text, gated only by `SOC_RTC_FAST_MEM_SUPPORTED`). It can only be turned on by another config's `select` line — writing `CONFIG_BOOTLOADER_RESERVE_RTC_MEM=y` directly into a downstream project's `sdkconfig.defaults` is silently ignored by Kconfig's resolver (confirmed empirically, including across `idf.py reconfigure`).

The result: any project that builds this component fresh, without already knowing this specific trick, hits:

```
error: implicit declaration of function 'bootloader_common_get_rtc_retain_mem'
error: 'rtc_retain_mem_t' has no member named 'custom'
```

The only user-visible symbol that reaches `BOOTLOADER_RESERVE_RTC_MEM` is `CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC` ("Reserve RTC FAST memory for custom purposes"), which itself does `select BOOTLOADER_RESERVE_RTC_MEM`. This component currently never sets it anywhere.

This was found via a from-scratch WHY2025-target build under ESP-IDF v6.0.2, but since `bsp_stub` links unconditionally, it should affect every `BSP_TARGET_*`, not just WHY2025.

## The fix

Add a hidden, always-on Kconfig helper (`BSP_RESERVE_RTC_RETAIN_MEM`, `default y`) inside the `menu "Badge.Team BSP"` block that does `select BOOTLOADER_CUSTOM_RESERVE_RTC`. This fixes it once at the component level instead of requiring every downstream project to discover and manually add `CONFIG_BOOTLOADER_CUSTOM_RESERVE_RTC=y` to their own `sdkconfig.defaults`, and instead of repeating the select on every one of the 11+ `BSP_TARGET_*` choice entries (a list that keeps growing).

A code-level `#ifdef` workaround inside `stub/badge_bsp_device.c` alone would not be sufficient: `bsp_device_restart_to_launcher()` is a weak symbol, so any per-target implementation that overrides it in the future would need the same RTC-retain support, not just the stub fallback. The Kconfig-level `select` covers both cases uniformly.

## Note

`badgeteam/appfs`'s `appfs.c` uses the identical RTC-retain mechanism for its own boot-select feature and likely has the same latent issue, but that's a separate component and out of scope for this PR.
